### PR TITLE
Combined dependency updates (2022-12-03)

### DIFF
--- a/TestDotnetBackground/TestDotnetBackground.csproj
+++ b/TestDotnetBackground/TestDotnetBackground.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Includes these updates:
- [Bump Microsoft.NET.Test.Sdk from 17.3.2 to 17.4.0](https://github.com/javiertuya/dotnet-background/pull/15)

Does not include these updates because of merge conflicts:
- [Bump NUnit3TestAdapter from 4.3.0 to 4.3.1](https://github.com/javiertuya/dotnet-background/pull/14)