### PR TITLE
Combined dependency updates (2025-09-02)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
       contents: read
       packages: write 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-dotnet@v4
         with:
             dotnet-version: '8.0.x'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         framework: ['net6.0', 'net8.0' ]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       #requires all sdks to compile and run, but tests and process will be exeucuted on each matrix framework
       - uses: actions/setup-dotnet@v4
         with:

--- a/TestDotnetBackground/TestDotnetBackground.csproj
+++ b/TestDotnetBackground/TestDotnetBackground.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="NUnit" Version="4.4.0" />
 
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
     
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
   </ItemGroup>

--- a/TestDotnetBackground/TestDotnetBackground.csproj
+++ b/TestDotnetBackground/TestDotnetBackground.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit" Version="4.4.0" />
 
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
     


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump NUnit from 4.3.2 to 4.4.0](https://github.com/javiertuya/dotnet-background/pull/55)
- [Bump actions/checkout from 4 to 5](https://github.com/javiertuya/dotnet-background/pull/54)
- [Bump NUnit3TestAdapter from 5.0.0 to 5.1.0](https://github.com/javiertuya/dotnet-background/pull/53)