### PR TITLE
Combined dependency updates (2026-04-05)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
       #prevents execution on PR or dependabot that fails with "Resource not accessible by integration" due to permissions
       - name: Publish test report
         if: ${{ always() && github.actor=='javiertuya' }} 
-        uses: dorny/test-reporter@v2
+        uses: dorny/test-reporter@v3
         with:
           name: test-report-${{ matrix.framework }}
           path: reports/nunit/dotnet-background-report.trx

--- a/TestDotnetBackground/TestDotnetBackground.csproj
+++ b/TestDotnetBackground/TestDotnetBackground.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="NUnit" Version="4.5.0" />
 
-    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
   </ItemGroup>

--- a/TestDotnetBackground/TestDotnetBackground.csproj
+++ b/TestDotnetBackground/TestDotnetBackground.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="4.5.0" />
+    <PackageReference Include="NUnit" Version="4.5.1" />
 
     <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
     


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump NUnit3TestAdapter from 6.1.0 to 6.2.0](https://github.com/javiertuya/dotnet-background/pull/75)
- [Bump NUnit from 4.5.0 to 4.5.1](https://github.com/javiertuya/dotnet-background/pull/74)
- [Bump dorny/test-reporter from 2 to 3](https://github.com/javiertuya/dotnet-background/pull/73)