### PR TITLE
Combined dependency updates (2026-07-04)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
       contents: read
       packages: write 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-dotnet@v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         framework: ['net8.0', 'net10.0']
       fail-fast: false
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       #requires all sdks to compile and run, but tests and process will be exeucuted on each matrix framework
       - uses: actions/setup-dotnet@v5
         with:

--- a/TestDotnetBackground/TestDotnetBackground.csproj
+++ b/TestDotnetBackground/TestDotnetBackground.csproj
@@ -11,7 +11,7 @@
 
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump Microsoft.NET.Test.Sdk from 18.6.0 to 18.7.0](https://github.com/javiertuya/dotnet-background/pull/83)
- [Bump actions/checkout from 6 to 7](https://github.com/javiertuya/dotnet-background/pull/82)